### PR TITLE
Feat: getChallenges , getChallenge ,createChallenge, participateChallenge구현 (완)

### DIFF
--- a/config/swagger.js
+++ b/config/swagger.js
@@ -1,0 +1,35 @@
+const swaggerJSDoc = require("swagger-jsdoc");
+
+const swaggerDefinition = {
+  openapi: "3.0.0",
+  info: {
+    title: "Docthru",
+    version: "1.0.0",
+    description: "API documentation for docthru",
+  },
+  components: {
+    securitySchemes: {
+      BearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+  },
+  // security: [{ BearerAuth: [] }],
+  servers: [
+    {
+      url: "http://localhost:5000", // 배포 후에는 실제 도메인으로 변경
+      description: "Local server",
+    },
+  ],
+};
+
+const options = {
+  swaggerDefinition,
+  apis: ["./docs/*.yaml"], // API 문서화할 파일 경로
+};
+
+const swaggerSpec = swaggerJSDoc(options);
+
+module.exports = swaggerSpec;

--- a/config/swagger.js
+++ b/config/swagger.js
@@ -22,6 +22,10 @@ const swaggerDefinition = {
       url: "http://localhost:5000", // 배포 후에는 실제 도메인으로 변경
       description: "Local server",
     },
+    {
+      url: "https://docthru-be-5u42.onrender.com", // 배포 후에는 실제 도메인으로 변경
+      description: "test server",
+    },
   ],
 };
 

--- a/docs/auth.yaml
+++ b/docs/auth.yaml
@@ -1,0 +1,144 @@
+paths:
+  /auth/signup:
+    post:
+      summary: 회원가입 API
+      description: 이메일, 닉네임, 비밀번호를 입력하여 회원가입을 진행합니다.
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - nickname
+                - password
+                - passwordConfirmation
+              properties:
+                email:
+                  type: string
+                  example: "test@example.com"
+                nickname:
+                  type: string
+                  example: "Eomseong"
+                password:
+                  type: string
+                  example: "qwer1234"
+                passwordConfirmation:
+                  type: string
+                  example: "qwer1234"
+      responses:
+        201:
+          description: 회원가입 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  email:
+                    type: string
+                    example: "test@example.com"
+                  nickname:
+                    type: string
+                    example: "Eomsung"
+                  createdAt:
+                    type: string
+                    format: date-time
+                    example: "2025-02-10T12:34:56.789Z"
+        400:
+          description: 입력값 오류 (잘못된 이메일 형식, 중복된 이메일 등)
+
+  /auth/login:
+    post:
+      summary: 로그인 API
+      description: 이메일과 비밀번호를 입력하여 로그인합니다.
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  example: "test@example.com"
+                password:
+                  type: string
+                  example: "qwer1234"
+      responses:
+        200:
+          description: 로그인 성공 (토큰 반환)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: "eyJhbGciOiJIUzI1NiIs..."
+                  refreshToken:
+                    type: string
+                    example: "eyJhbGciOiJIUzI1NiIs..."
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        example: "00733f16-43b4-4dd8-9428-9866f15f9848"
+                      email:
+                        type: string
+                        example: "test@12345.com"
+                      nickname:
+                        type: string
+                        example: "테스트"
+                      createdAt:
+                        type: string
+                        format: date-time
+                        example: "2025-02-10T05:11:34.377Z"
+        401:
+          description: 로그인 실패 (잘못된 자격 증명, 이메일이 존재 하지 않음, 비밀번호가 틀림)
+
+  /auth/refreshToken:
+    post:
+      summary: refreshToken API
+      description: refreshToken으로 accessToken 재발급하는 API입니다다.
+      tags:
+        - Auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - refreshToken
+              properties:
+                refreshToken:
+                  type: string
+                  example: "eyJhbGciOiJIUzI1NiIs..."
+      responses:
+        200:
+          description: 성공 (토큰 반환)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accessToken:
+                    type: string
+                    example: "eyJhbGciOiJIUzI1NiIs..."
+                  refreshToken:
+                    type: string
+                    example: "eyJhbGciOiJIUzI1NiIs..."
+        400:
+          description: 실패 (유효하지 않은 refreshToken 일 가능성이 있음, 등등 )

--- a/docs/uers.yaml
+++ b/docs/uers.yaml
@@ -1,0 +1,48 @@
+paths:
+  /user/signup:
+    post:
+      summary: 회원가s입 API
+      description: 이메일, 닉네임, 비밀번호를 입력하여 회원가입을 진행합니다.
+      security:
+        - BearerAuth: []
+      tags:
+        - user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email
+                - nickname
+                - password
+              properties:
+                email:
+                  type: string
+                  example: "test@example.com"
+                nickname:
+                  type: string
+                  example: "JohnDoe"
+                password:
+                  type: string
+                  example: "securepassword123"
+      responses:
+        201:
+          description: 회원가입 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  email:
+                    type: string
+                    example: "test@example.com"
+                  nickname:
+                    type: string
+                    example: "JohnDoe"
+        400:
+          description: 입력값 오류 (잘못된 이메일 형식, 중복된 이메일 등)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "jsonwebtoken": "^9.0.2",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^11.0.5",
         "zod": "^3.24.1"
       },
@@ -23,6 +25,56 @@
         "nodemon": "^3.1.9",
         "prisma": "^6.3.1"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
@@ -116,6 +168,13 @@
         "@prisma/debug": "6.3.1"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/bcrypt": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
@@ -125,6 +184,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.13.1",
@@ -232,6 +297,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -363,6 +434,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -404,6 +481,15 @@
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -510,6 +596,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -601,6 +699,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1056,6 +1163,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1105,6 +1224,13 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1115,6 +1241,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -1139,6 +1272,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -1472,6 +1611,13 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1892,6 +2038,83 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.3.tgz",
+      "integrity": "sha512-G33HFW0iFNStfY2x6QXO2JYVMrFruc8AZRX0U/L71aA7WeWfX2E5Nm8E/tsipSZJeIZZbSjUDeynLK/wcuNWIw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -2011,6 +2234,15 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2056,6 +2288,45 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/zod": {
       "version": "3.24.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,38 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.3.1",
+        "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
-        "uuid": "^11.0.5"
+        "jsonwebtoken": "^9.0.2",
+        "uuid": "^11.0.5",
+        "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@types/bcrypt": "^5.0.2",
         "nodemon": "^3.1.9",
         "prisma": "^6.3.1"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
     "node_modules/@prisma/client": {
@@ -92,6 +116,32 @@
         "@prisma/debug": "6.3.1"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
+      "integrity": "sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
+      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC"
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -103,6 +153,50 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/anymatch": {
@@ -119,6 +213,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+      "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+      "license": "ISC"
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -129,8 +243,21 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -173,7 +300,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -192,6 +318,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -256,12 +388,35 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -321,6 +476,12 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -338,6 +499,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -366,10 +536,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -521,6 +706,36 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -543,6 +758,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-intrinsic": {
@@ -580,6 +816,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -629,6 +886,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -657,6 +920,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -675,6 +974,17 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -714,6 +1024,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -735,6 +1054,121 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/math-intrinsics": {
@@ -810,13 +1244,58 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -832,6 +1311,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/nodemon": {
@@ -888,6 +1393,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -896,6 +1416,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -931,6 +1464,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -938,6 +1480,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1046,6 +1597,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1057,6 +1622,22 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/safe-buffer": {
@@ -1089,7 +1670,6 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1151,6 +1731,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1230,6 +1816,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1252,6 +1844,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1263,6 +1890,23 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/to-regex-range": {
@@ -1297,6 +1941,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1317,6 +1967,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1325,6 +1982,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -1355,6 +2018,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "nodemon src/app.js"
+    "dev": "nodemon src/app.js",
+    "start": "node src/app.js"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,16 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.3.1",
+    "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
-    "uuid": "^11.0.5"
+    "jsonwebtoken": "^9.0.2",
+    "uuid": "^11.0.5",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
     "nodemon": "^3.1.9",
     "prisma": "^6.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^11.0.5",
     "zod": "^3.24.1"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,14 @@
 require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
+const swaggerUi = require("swagger-ui-express");
+
 const router = require("./controllers/route");
 const { errorHandler } = require("./middlewares/error.middleware");
+const swaggerSpec = require("../config/swagger");
 
 const app = express();
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // 미들웨어
 app.use(cors());

--- a/src/controllers/auth/auth.route.js
+++ b/src/controllers/auth/auth.route.js
@@ -1,9 +1,15 @@
 const express = require("express");
+const authService = require("../../services/auth.service");
+const {
+  validateSignUpContext,
+  validateLogInContext,
+} = require("../../validate/auth.validate");
 
 const authRouter = express.Router();
 
-authRouter.post("/signUp");
-authRouter.post("/login");
-authRouter.post("/logout");
+authRouter.post("/signUp", validateSignUpContext, authService.signUp);
+authRouter.post("/login", validateLogInContext, authService.logIn);
+authRouter.post("/refreshToken", authService.refreshToken);
+authRouter.post("/logout", authService.refreshToken);
 
 module.exports = authRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -7,14 +7,18 @@ const {
 const { authenticatedOnly } = require("../../middlewares/auth.middleeware");
 
 const challengeRouter = express.Router();
-
+//챌린지 목록 보기
 challengeRouter.get("/", validateGetChallenges, challengeService.getChallenges);
+//특정 챌린지 복기기
 challengeRouter.get("/:challengeId", challengeService.getChallenge);
+// 챌린지 생성
 challengeRouter.post(
   "/",
   validateCreateChallenge,
   authenticatedOnly,
   challengeService.createChallenge
 );
+// 챌린지 참여하기
+challengeRouter.post("/:challengeId/participation");
 
 module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -19,6 +19,9 @@ challengeRouter.post(
   challengeService.createChallenge
 );
 // 챌린지 참여하기
-challengeRouter.post("/:challengeId/participation");
+challengeRouter.post(
+  "/:challengeId/participation",
+  challengeService.ParticipateChallenge
+);
 
 module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -1,10 +1,20 @@
 const express = require("express");
 const { challengeService } = require("../../services/challenge.service");
-const { validateGetChallenges } = require("../../validate/challenge.validate");
+const {
+  validateGetChallenges,
+  validateCreateChallenge,
+} = require("../../validate/challenge.validate");
+const { authenticatedOnly } = require("../../middlewares/auth.middleeware");
 
 const challengeRouter = express.Router();
 
 challengeRouter.get("/", validateGetChallenges, challengeService.getChallenges);
 challengeRouter.get("/:challengeId", challengeService.getChallenge);
+challengeRouter.post(
+  "/",
+  validateCreateChallenge,
+  authenticatedOnly,
+  challengeService.createChallenge
+);
 
 module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -5,5 +5,6 @@ const { validateGetChallenges } = require("../../validate/challenge.validate");
 const challengeRouter = express.Router();
 
 challengeRouter.get("/", validateGetChallenges, challengeService.getChallenges);
+challengeRouter.get("/:challengeId", challengeService.getChallenge);
 
 module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -21,7 +21,7 @@ challengeRouter.post(
 // 챌린지 참여하기
 challengeRouter.post(
   "/:challengeId/participation",
-  challengeService.ParticipateChallenge
+  challengeService.participateChallenge
 );
 
 module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const { challengeService } = require("../../services/challenge.service");
+
+const challengeRouter = express.Router();
+
+challengeRouter.get("/", challengeService.getChallenges);
+
+module.exports = challengeRouter;

--- a/src/controllers/challenges/challenge.route.js
+++ b/src/controllers/challenges/challenge.route.js
@@ -1,8 +1,9 @@
 const express = require("express");
 const { challengeService } = require("../../services/challenge.service");
+const { validateGetChallenges } = require("../../validate/challenge.validate");
 
 const challengeRouter = express.Router();
 
-challengeRouter.get("/", challengeService.getChallenges);
+challengeRouter.get("/", validateGetChallenges, challengeService.getChallenges);
 
 module.exports = challengeRouter;

--- a/src/controllers/route.js
+++ b/src/controllers/route.js
@@ -1,10 +1,12 @@
 const express = require("express");
 const authRouter = require("./auth/auth.route");
 const { authMiddleware } = require("../middlewares/auth.middleeware");
+const challengeRouter = require("./challenges/challenge.route");
 
 const router = express.Router();
 
 router.use(authMiddleware);
 router.use("/auth", authRouter);
+router.use("/challenges", challengeRouter);
 
 module.exports = router;

--- a/src/controllers/route.js
+++ b/src/controllers/route.js
@@ -1,8 +1,10 @@
 const express = require("express");
 const authRouter = require("./auth/auth.route");
+const { authMiddleware } = require("../middlewares/auth.middleeware");
 
 const router = express.Router();
 
+router.use(authMiddleware);
 router.use("/auth", authRouter);
 
 module.exports = router;

--- a/src/db/prisma/client.js
+++ b/src/db/prisma/client.js
@@ -1,11 +1,7 @@
 const { PrismaClient } = require("@prisma/client");
 
 const prisma = new PrismaClient({
-//   omit: {
-//     user: {
-//       encryptedPassword: true,
-//     },
-//   },
+  omit: { user: { encryptedPassword: true } },
 });
 
 module.exports = prisma;

--- a/src/db/prisma/migrations/20250210040526_update_user/migration.sql
+++ b/src/db/prisma/migrations/20250210040526_update_user/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `encryptedPassword` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "encryptedPassword" TEXT NOT NULL;

--- a/src/db/prisma/migrations/20250210040903_update_user_add_nickname/migration.sql
+++ b/src/db/prisma/migrations/20250210040903_update_user_add_nickname/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `nickname` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "nickname" TEXT NOT NULL;

--- a/src/db/prisma/migrations/20250210041828_update_user_delete_name_field/migration.sql
+++ b/src/db/prisma/migrations/20250210041828_update_user_delete_name_field/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `name` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "name";

--- a/src/db/prisma/migrations/20250210050807_/migration.sql
+++ b/src/db/prisma/migrations/20250210050807_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[nickname]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_nickname_key" ON "User"("nickname");

--- a/src/db/prisma/migrations/20250210082335_update_user_and_add_challenge/migration.sql
+++ b/src/db/prisma/migrations/20250210082335_update_user_and_add_challenge/migration.sql
@@ -1,0 +1,30 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('GENERAL', 'EXPERT', 'ADMIN');
+
+-- CreateEnum
+CREATE TYPE "Grade" AS ENUM ('GENERAL', 'EXPERT');
+
+-- CreateEnum
+CREATE TYPE "Field" AS ENUM ('NEXTJS', 'CAREER', 'MODERNJS', 'WEB');
+
+-- CreateEnum
+CREATE TYPE "DocType" AS ENUM ('BLOG', 'DOCS');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "grade" "Grade",
+ADD COLUMN     "role" "Role";
+
+-- CreateTable
+CREATE TABLE "Challenge" (
+    "id" TEXT NOT NULL,
+    "tilte" TEXT NOT NULL,
+    "field" "Field" NOT NULL,
+    "docType" "DocType" NOT NULL,
+    "docUrl" TEXT NOT NULL,
+    "deadLine" TIMESTAMP(3) NOT NULL,
+    "progress" BOOLEAN NOT NULL DEFAULT false,
+    "participants" INTEGER NOT NULL,
+    "maxParticipants" INTEGER NOT NULL,
+
+    CONSTRAINT "Challenge_pkey" PRIMARY KEY ("id")
+);

--- a/src/db/prisma/migrations/20250210082403_delete_optional_in_user/migration.sql
+++ b/src/db/prisma/migrations/20250210082403_delete_optional_in_user/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Made the column `grade` on table `User` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `role` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "grade" SET NOT NULL,
+ALTER COLUMN "role" SET NOT NULL;

--- a/src/db/prisma/migrations/20250210090122_add_application/migration.sql
+++ b/src/db/prisma/migrations/20250210090122_add_application/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "ApplicationStatus" AS ENUM ('WAITING', 'ACCEPTED', 'REJECTED', 'DELTED');
+
+-- CreateTable
+CREATE TABLE "Application" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "challengeId" TEXT NOT NULL,
+    "status" "ApplicationStatus" NOT NULL DEFAULT 'WAITING',
+    "appliedAt" TIMESTAMP(3) NOT NULL,
+    "invalidationComment" TEXT,
+    "invaildatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "Application_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Application" ADD CONSTRAINT "Application_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "Challenge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/db/prisma/migrations/20250210094102_/migration.sql
+++ b/src/db/prisma/migrations/20250210094102_/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `tilte` on the `Challenge` table. All the data in the column will be lost.
+  - Added the required column `title` to the `Challenge` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Challenge" DROP COLUMN "tilte",
+ADD COLUMN     "title" TEXT NOT NULL;

--- a/src/db/prisma/migrations/20250210095159_/migration.sql
+++ b/src/db/prisma/migrations/20250210095159_/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "grade" DROP NOT NULL,
+ALTER COLUMN "role" DROP NOT NULL;

--- a/src/db/prisma/migrations/20250211003023_/migration.sql
+++ b/src/db/prisma/migrations/20250211003023_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Field" ADD VALUE 'API';

--- a/src/db/prisma/migrations/20250211040211_add_unique/migration.sql
+++ b/src/db/prisma/migrations/20250211040211_add_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,challengeId]` on the table `Application` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Application_userId_challengeId_key" ON "Application"("userId", "challengeId");

--- a/src/db/prisma/migrations/20250211050623_/migration.sql
+++ b/src/db/prisma/migrations/20250211050623_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Challenge" ADD COLUMN     "content" TEXT;

--- a/src/db/prisma/migrations/20250211050825_/migration.sql
+++ b/src/db/prisma/migrations/20250211050825_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Application" ALTER COLUMN "appliedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/src/db/prisma/migrations/20250211051143_/migration.sql
+++ b/src/db/prisma/migrations/20250211051143_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Challenge" ALTER COLUMN "participants" SET DEFAULT 1;

--- a/src/db/prisma/migrations/20250211052516_add_participate/migration.sql
+++ b/src/db/prisma/migrations/20250211052516_add_participate/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "Participate" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "challengeId" TEXT NOT NULL,
+
+    CONSTRAINT "Participate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participate_userId_challengeId_key" ON "Participate"("userId", "challengeId");
+
+-- AddForeignKey
+ALTER TABLE "Participate" ADD CONSTRAINT "Participate_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Participate" ADD CONSTRAINT "Participate_challengeId_fkey" FOREIGN KEY ("challengeId") REFERENCES "Challenge"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/src/db/prisma/migrations/20250211060809_/migration.sql
+++ b/src/db/prisma/migrations/20250211060809_/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[challengeId]` on the table `Application` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "Application_userId_challengeId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Application_challengeId_key" ON "Application"("challengeId");

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -20,8 +20,9 @@ model User {
   nickname          String        @unique
   createdAt         DateTime      @default(now())
   grade             Grade?
-  role              Role?  // 임시로
+  role              Role? // 임시로
   Application       Application[]
+  Participate       Participate[]
 }
 
 model Challenge {
@@ -32,9 +33,12 @@ model Challenge {
   docUrl          String
   deadLine        DateTime
   progress        Boolean       @default(false)
-  participants    Int
+  participants    Int           @default(1)
   maxParticipants Int
+  content         String?
   Application     Application[]
+
+  Participate Participate[]
 }
 
 model Application {
@@ -44,9 +48,21 @@ model Application {
   userId              String
   challengeId         String
   status              ApplicationStatus @default(WAITING)
-  appliedAt           DateTime
+  appliedAt           DateTime          @default(now())
   invalidationComment String?
   invaildatedAt       DateTime?
+
+  @@unique([userId, challengeId])
+}
+
+model Participate {
+  id          String    @id @default(uuid())
+  user        User      @relation(fields: [userId], references: [id])
+  challenge   Challenge @relation(fields: [challengeId], references: [id])
+  userId      String
+  challengeId String
+
+  @@unique([userId, challengeId])
 }
 
 //바뀔예정 

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -21,8 +21,8 @@ model User {
   createdAt         DateTime      @default(now())
   grade             Grade?
   role              Role? // 임시로
-  Application       Application[]
-  Participate       Participate[]
+  application       Application[]
+  participate       Participate[]
 }
 
 model Challenge {
@@ -36,9 +36,9 @@ model Challenge {
   participants    Int           @default(1)
   maxParticipants Int
   content         String?
-  Application     Application[]
+  application     Application?
 
-  Participate Participate[]
+  participate Participate[]
 }
 
 model Application {
@@ -46,13 +46,12 @@ model Application {
   user                User              @relation(fields: [userId], references: [id])
   challenge           Challenge         @relation(fields: [challengeId], references: [id])
   userId              String
-  challengeId         String
+  challengeId         String            @unique
   status              ApplicationStatus @default(WAITING)
   appliedAt           DateTime          @default(now())
   invalidationComment String?
   invaildatedAt       DateTime?
 
-  @@unique([userId, challengeId])
 }
 
 model Participate {

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -14,10 +14,11 @@ datasource db {
 }
 
 model User {
-  id    String @id @default(uuid())
-  name  String
-  email String @unique
-  //비밀번호(암호화)
+  id                String   @id @default(uuid())
+  email             String   @unique
+  encryptedPassword String
+  nickname          String   @unique
+  createdAt         DateTime @default(now())
   // 유저 등급 - 전문가,일반
   //
 }

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -14,11 +14,68 @@ datasource db {
 }
 
 model User {
-  id                String   @id @default(uuid())
-  email             String   @unique
+  id                String        @id @default(uuid())
+  email             String        @unique
   encryptedPassword String
-  nickname          String   @unique
-  createdAt         DateTime @default(now())
-  // 유저 등급 - 전문가,일반
-  //
+  nickname          String        @unique
+  createdAt         DateTime      @default(now())
+  grade             Grade
+  role              Role
+  Application       Application[]
+}
+
+model Challenge {
+  id              String        @id @default(uuid())
+  title           String
+  field           Field
+  docType         DocType
+  docUrl          String
+  deadLine        DateTime
+  progress        Boolean       @default(false)
+  participants    Int
+  maxParticipants Int
+  Application     Application[]
+}
+
+model Application {
+  id                  String            @id @default(uuid())
+  user                User              @relation(fields: [userId], references: [id])
+  challenge           Challenge         @relation(fields: [challengeId], references: [id])
+  userId              String
+  challengeId         String
+  status              ApplicationStatus @default(WAITING)
+  appliedAt           DateTime
+  invalidationComment String?
+  invaildatedAt       DateTime?
+}
+
+//바뀔예정 
+enum Role {
+  GENERAL
+  EXPERT
+  ADMIN
+}
+
+enum Grade {
+  GENERAL
+  EXPERT
+}
+
+enum Field {
+  NEXTJS
+  CAREER
+  MODERNJS
+  WEB
+}
+
+enum DocType {
+  BLOG
+  DOCS
+}
+
+enum ApplicationStatus {
+  WAITING
+  ACCEPTED
+  REJECTED
+  DELTED
 }

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -19,8 +19,8 @@ model User {
   encryptedPassword String
   nickname          String        @unique
   createdAt         DateTime      @default(now())
-  grade             Grade
-  role              Role
+  grade             Grade?
+  role              Role?  // 임시로
   Application       Application[]
 }
 
@@ -66,6 +66,7 @@ enum Field {
   CAREER
   MODERNJS
   WEB
+  API
 }
 
 enum DocType {

--- a/src/middlewares/auth.middleeware.js
+++ b/src/middlewares/auth.middleeware.js
@@ -1,0 +1,20 @@
+const jwt = require("jsonwebtoken");
+const jwtSecretKey = process.env.JWT_SECRET_KEY;
+
+function authMiddleware(req, res, next) {
+  try {
+    if (req.url === "/auth/signUp" || req.url === "/auth/logIn") return next();
+    const token = req.headers.authorization;
+    if (!token) {
+      return next();
+    }
+    const accessToken = token.split("Bearer ")[1];
+    const { sub } = jwt.verify(accessToken, jwtSecretKey);
+    req.userId = sub;
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+module.exports = { authMiddleware };

--- a/src/middlewares/auth.middleeware.js
+++ b/src/middlewares/auth.middleeware.js
@@ -17,4 +17,16 @@ function authMiddleware(req, res, next) {
   }
 }
 
+function authenticatedOnly(req, res, next) {
+  try {
+    const userId = req.userId;
+    const isAuthenticated = !!userId;
+    if (!isAuthenticated) throw new Error("401/Unauthenticated");
+
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
 module.exports = { authMiddleware };

--- a/src/middlewares/auth.middleeware.js
+++ b/src/middlewares/auth.middleeware.js
@@ -29,4 +29,4 @@ function authenticatedOnly(req, res, next) {
   }
 }
 
-module.exports = { authMiddleware };
+module.exports = { authMiddleware, authenticatedOnly };

--- a/src/middlewares/error.middleware.js
+++ b/src/middlewares/error.middleware.js
@@ -9,7 +9,7 @@ function errorHandler(err, req, res, next) {
   if (isNaN(statusCode)) return res.status(500).send("unknown error");
 
   res.status(statusCode).send(message);
-  res.status(500).send({ message: e.message });
+  res.status(500).send({ message: err.message });
 }
 
 function asyncHandler(handler) {

--- a/src/middlewares/error.middleware.js
+++ b/src/middlewares/error.middleware.js
@@ -1,3 +1,5 @@
+const { Prisma } = require("@prisma/client");
+
 function errorHandler(err, req, res, next) {
   console.error("error는 ", err);
 

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -1,7 +1,86 @@
 const prisma = require("../db/prisma/client");
+const bcrypt = require("bcrypt");
 const { asyncHandler } = require("../middlewares/error.middleware");
+const jwt = require("jsonwebtoken");
+const jwtSecretKey = process.env.JWT_SECRET_KEY;
 
-const signUp = asyncHandler(async (req, res, next) => {});
-const authService = { signUp };
+function createToken(data) {
+  try {
+    const payload = {
+      sub: data.id,
+      email: data.email,
+      nickname: data.nickname,
+    };
+    const accessToken = jwt.sign(payload, jwtSecretKey, {
+      expiresIn: "2h",
+    });
+    const refreshToken = jwt.sign(payload, jwtSecretKey, {
+      expiresIn: "5d",
+    });
+    return { accessToken, refreshToken };
+  } catch (e) {
+    throw new Error(e);
+  }
+}
+
+const signUp = asyncHandler(async (req, res, next) => {
+  const { email, password, nickname } = req.body;
+  const encryptedPassword = await bcrypt.hash(password, 12);
+
+  const existingUser = await prisma.user.findUnique({
+    where: { email },
+    omit: { encryptedPassword: true },
+  });
+  if (existingUser) throw new Error("400/email already exist");
+
+  const newUser = await prisma.user.create({
+    data: { email, encryptedPassword, nickname },
+  });
+
+  res.status(200).send(newUser);
+});
+
+const logIn = asyncHandler(async (req, res, next) => {
+  const result = await prisma.$transaction(async (prisma) => {
+    const { email, password } = req.body;
+    const existingUser = await prisma.user.findUnique({
+      where: { email },
+      select: { encryptedPassword: true },
+    });
+    if (!existingUser) throw new Error("400/user does not exist");
+    const passwordCheck = await bcrypt.compare(
+      password,
+      existingUser.encryptedPassword
+    );
+    if (!passwordCheck) throw new Error("400/Incorrect password");
+
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { email },
+    });
+    const data = {
+      id: user.id,
+      email: user.email,
+      nickname: user.nickname,
+    };
+    const { accessToken, refreshToken } = createToken(data);
+    return { accessToken, refreshToken, user };
+  });
+
+  res.status(201).send(result);
+});
+
+const refreshToken = asyncHandler(async (req, res, next) => {
+  const { refreshToken: prevRefreshToken } = req.body;
+  const { sub, email, nickname } = jwt.verify(prevRefreshToken, jwtSecretKey);
+  const data = {
+    id: sub,
+    email,
+    nickname,
+  };
+  const { accessToken } = createToken(data);
+  res.status(200).send({ accessToken });
+});
+
+const authService = { signUp, logIn, refreshToken };
 
 module.exports = authService;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -27,11 +27,17 @@ const signUp = asyncHandler(async (req, res, next) => {
   const { email, password, nickname } = req.body;
   const encryptedPassword = await bcrypt.hash(password, 12);
 
-  const existingUser = await prisma.user.findUnique({
+  let existingUser = await prisma.user.findUnique({
     where: { email },
     omit: { encryptedPassword: true },
   });
   if (existingUser) throw new Error("400/email already exist");
+
+  existingUser = await prisma.user.findUnique({
+    where: { nickname },
+    omit: { encryptedPassword: true },
+  });
+  if (existingUser) throw new Error("400/nickname already exist");
 
   const newUser = await prisma.user.create({
     data: { email, encryptedPassword, nickname },

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -37,7 +37,7 @@ const signUp = asyncHandler(async (req, res, next) => {
     data: { email, encryptedPassword, nickname },
   });
 
-  res.status(200).send(newUser);
+  res.status(201).send(newUser);
 });
 
 const logIn = asyncHandler(async (req, res, next) => {
@@ -47,12 +47,12 @@ const logIn = asyncHandler(async (req, res, next) => {
       where: { email },
       select: { encryptedPassword: true },
     });
-    if (!existingUser) throw new Error("400/user does not exist");
+    if (!existingUser) throw new Error("401/user does not exist");
     const passwordCheck = await bcrypt.compare(
       password,
       existingUser.encryptedPassword
     );
-    if (!passwordCheck) throw new Error("400/Incorrect password");
+    if (!passwordCheck) throw new Error("401/Incorrect password");
 
     const user = await prisma.user.findUniqueOrThrow({
       where: { email },
@@ -77,8 +77,8 @@ const refreshToken = asyncHandler(async (req, res, next) => {
     email,
     nickname,
   };
-  const { accessToken } = createToken(data);
-  res.status(200).send({ accessToken });
+  const { accessToken, refreshToken } = createToken(data);
+  res.status(200).send({ accessToken, refreshToken });
 });
 
 const authService = { signUp, logIn, refreshToken };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -6,11 +6,6 @@ const getChallenges = asyncHandler(async (req, res, next) => {
   const { cursor, pageSize, keyword, orderBy, field, docType, progress } =
     req.query;
 
-  // switch (x) {
-  //   case "waiting":
-  //   const sortOption = {}
-  // }
-
   const search = {
     OR: keyword
       ? [{ title: { contains: keyword, mode: "insensitive" } }]
@@ -24,7 +19,6 @@ const getChallenges = asyncHandler(async (req, res, next) => {
     where: search,
     take: pageSize,
     cursor: cursor ? { id: cursor } : undefined,
-    // orderBy:sortOption,
   });
   const nextCursor =
     challenges.length === pageSize
@@ -34,5 +28,13 @@ const getChallenges = asyncHandler(async (req, res, next) => {
   res.status(200).send({ challenges, nextCursor });
 });
 
-const challengeService = { getChallenges };
+const getChallenge = asyncHandler(async (req, res, next) => {
+  const challengeId = req.params.challengeId;
+  const challenge = await prisma.challenge.findFirstOrThrow({
+    where: { id: challengeId },
+  });
+  res.status(200).send(challenge);
+});
+
+const challengeService = { getChallenges, getChallenge };
 module.exports = { challengeService };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -64,7 +64,7 @@ const createChallenge = asyncHandler(async (req, res, next) => {
   res.status(200).send(result);
 });
 
-const ParticipateChallenge = asyncHandler(async (req, res, next) => {
+const participateChallenge = asyncHandler(async (req, res, next) => {
   //1.useId 찾기
   //2.해당 챌린지 찾기기
   //3.해당 챌린지에 남은 인원이 있는지 확인하고 상태도 검사해야함 ACCEPTED 상태인지 //
@@ -115,6 +115,6 @@ const challengeService = {
   getChallenges,
   getChallenge,
   createChallenge,
-  ParticipateChallenge,
+  participateChallenge,
 };
 module.exports = { challengeService };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -1,0 +1,26 @@
+const prisma = require("../db/prisma/client");
+const { asyncHandler } = require("../middlewares/error.middleware");
+
+const getChallenges = asyncHandler(async (req, res, next) => {
+  const { cursor, pageSize, keyword, orderBy } = req.query;
+
+  //   const sortOption
+
+  const search = keyword
+    ? {
+        OR: [{ title: { contains: keyword, mode: "insensitive" } }],
+      }
+    : {};
+
+  const challenges = await prisma.challenge.findMany({
+    where: search,
+    take: pageSize,
+    cursor: cursor ? { id: cursor } : undefined,
+    // orderBy:sortOption,
+  });
+
+  res.status(200).send(challenges);
+});
+
+const challengeService = { getChallenges };
+module.exports = { challengeService };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -2,7 +2,7 @@ const prisma = require("../db/prisma/client");
 const { asyncHandler } = require("../middlewares/error.middleware");
 
 const getChallenges = asyncHandler(async (req, res, next) => {
-  //application 에서 신청 상태를 확인도 해야함 나중에 추가
+  //application 에서 status가 ACCEPTED 추가해야함 신청 상태를 확인도 해야함 나중에 추가
   const { cursor, pageSize, keyword, orderBy, field, docType, progress } =
     req.query;
 
@@ -13,6 +13,9 @@ const getChallenges = asyncHandler(async (req, res, next) => {
     field: field ? field : undefined,
     docType: docType ? docType : undefined,
     progress: progress ? progress : undefined,
+    application: {
+      status: "ACCEPTED",
+    },
   };
 
   const challenges = await prisma.challenge.findMany({
@@ -59,6 +62,14 @@ const createChallenge = asyncHandler(async (req, res, next) => {
     return newChallenge;
   });
   res.status(200).send(result);
+});
+
+const participateChallenge = asyncHandler(async (req, res, next) => {
+  //1.useId 찾기
+  //2.해당 챌린지 찾기
+  //3.해당 챌린지에 남은 인원이 있는지 확인 //
+  //4.남은 인원이 있으면 카운트 올리고 create participate
+  //5.끝
 });
 
 const challengeService = { getChallenges, getChallenge, createChallenge };

--- a/src/services/challenge.service.js
+++ b/src/services/challenge.service.js
@@ -1,16 +1,24 @@
+const { DocType } = require("@prisma/client");
 const prisma = require("../db/prisma/client");
 const { asyncHandler } = require("../middlewares/error.middleware");
 
 const getChallenges = asyncHandler(async (req, res, next) => {
-  const { cursor, pageSize, keyword, orderBy } = req.query;
+  const { cursor, pageSize, keyword, orderBy, field, docType, progress } =
+    req.query;
 
-  //   const sortOption
+  // switch (x) {
+  //   case "waiting":
+  //   const sortOption = {}
+  // }
 
-  const search = keyword
-    ? {
-        OR: [{ title: { contains: keyword, mode: "insensitive" } }],
-      }
-    : {};
+  const search = {
+    OR: keyword
+      ? [{ title: { contains: keyword, mode: "insensitive" } }]
+      : undefined,
+    field: field ? field : undefined,
+    docType: docType ? docType : undefined,
+    progress: progress ? progress : undefined,
+  };
 
   const challenges = await prisma.challenge.findMany({
     where: search,
@@ -18,8 +26,12 @@ const getChallenges = asyncHandler(async (req, res, next) => {
     cursor: cursor ? { id: cursor } : undefined,
     // orderBy:sortOption,
   });
+  const nextCursor =
+    challenges.length === pageSize
+      ? challenges[challenges.length - 1].id
+      : null;
 
-  res.status(200).send(challenges);
+  res.status(200).send({ challenges, nextCursor });
 });
 
 const challengeService = { getChallenges };

--- a/src/validate/auth.validate.js
+++ b/src/validate/auth.validate.js
@@ -1,0 +1,63 @@
+const { z } = require("zod");
+
+const signUpContextSchema = z.object({
+  email: z.string().email({ message: "Invalid email addess" }),
+  nickname: z
+    .string()
+    .min(1, { message: "nickname must be 1 or more characters long" })
+    .max(20, { message: "nickname must be 20 or fewer characters long" }),
+  password: z
+    .string()
+    .min(8, { message: "password must be 8 or more characters long" }),
+  passwordConfirmation: z
+    .string()
+    .min(8, { message: "password must be 8 or more characters long" })
+    .refine((data) => data.passwordConfirmation === data.password, {
+      message: "password don't match ",
+    }),
+});
+
+const logInContextSchema = z.object({
+  email: z.string().email({ message: "Invalid email addess" }),
+  password: z
+    .string()
+    .min(8, { message: "password must be 8 or more characters long" }),
+});
+
+function validateSignUpContext(req, res, next) {
+  try {
+    const parsedContext = signUpContextSchema.safeParse({
+      email: req.body.email,
+      nickname: req.body.nickname,
+      password: req.body.password,
+      passwordConfirmation: req.body.passwordConfirmation,
+    });
+
+    if (!parsedContext.success) {
+      throw new Error(`400/Validation error: ${parsedContext.error}`);
+    }
+    req.body = parsedContext.data;
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+function validateLogInContext(req, res, next) {
+  try {
+    const parsedContext = logInContextSchema.safeParse({
+      email: req.body.email,
+      password: req.body.password,
+    });
+
+    if (!parsedContext.success) {
+      throw new Error(`400/Validation error: ${parsedContext.error}`);
+    }
+    req.body = parsedContext.data;
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+module.exports = { validateSignUpContext, validateLogInContext };

--- a/src/validate/challenge.validate.js
+++ b/src/validate/challenge.validate.js
@@ -18,6 +18,16 @@ const searchSchema = z.object({
     .optional(),
 });
 
+const createChallengeSchema = z.object({
+  title: z.string(),
+  field: fieldEnum,
+  docType: docTypeEnum,
+  docUrl: z.string().url({ message: "docUrl does not invalid " }),
+  deadLine: z.coerce.date(),
+  maxParticipants: z.number().int(),
+  content: z.string(),
+});
+
 function validateGetChallenges(req, res, next) {
   try {
     const parsedOption = searchSchema.safeParse({
@@ -39,6 +49,29 @@ function validateGetChallenges(req, res, next) {
   }
 }
 
+function validateCreateChallenge(req, res, next) {
+  try {
+    const parsedBody = createChallengeSchema.safeParse({
+      title: req.body.title,
+      field: req.body.field,
+      docType: req.body.docType,
+      docUrl: req.body.docUrl,
+      deadLine: req.body.deadLine,
+      maxParticipants: Number(req.body.maxParticipants),
+      content: req.body.content,
+    });
+
+    if (!parsedBody.success) {
+      throw new Error(`400/Validation error: ${parsedBody.error}`);
+    }
+    req.query = parsedBody.data;
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
 module.exports = {
   validateGetChallenges,
+  validateCreateChallenge,
 };

--- a/src/validate/challenge.validate.js
+++ b/src/validate/challenge.validate.js
@@ -22,7 +22,7 @@ function validateGetChallenges(req, res, next) {
   try {
     const parsedOption = searchSchema.safeParse({
       cursor: req.query.cursor,
-      pageSize: req.query.pageSize ? req.query.pageSize : 5,
+      pageSize: req.query.pageSize ? Number(req.query.pageSize) : 5,
       keyword: req.query.keyword,
       field: req.query.field,
       docType: req.query.docType,

--- a/src/validate/challenge.validate.js
+++ b/src/validate/challenge.validate.js
@@ -1,0 +1,44 @@
+const { z } = require("zod");
+
+const fieldEnum = z.enum(["NEXTJS", "CAREER", "MODERNJS", "WEB", "API"]);
+const docTypeEnum = z.enum(["BLOG", "DOCS"]);
+
+const searchSchema = z.object({
+  cursor: z.string().optional(),
+  pageSize: z.number().int().optional(),
+  keyword: z.string().optional(),
+  field: fieldEnum.optional(),
+  docType: docTypeEnum.optional(),
+  progress: z
+    .string()
+    .refine((val) => val === "true" || val === "false", {
+      message: "progress must be 'true' or 'flale' ",
+    })
+    .transform((val) => val === "true")
+    .optional(),
+});
+
+function validateGetChallenges(req, res, next) {
+  try {
+    const parsedOption = searchSchema.safeParse({
+      cursor: req.query.cursor,
+      pageSize: req.query.pageSize ? req.query.pageSize : 5,
+      keyword: req.query.keyword,
+      field: req.query.field,
+      docType: req.query.docType,
+      progress: req.query.progress,
+    });
+
+    if (!parsedOption.success) {
+      throw new Error(`400/Validation error: ${parsedOption.error}`);
+    }
+    req.query = parsedOption.data;
+    next();
+  } catch (e) {
+    next(e);
+  }
+}
+
+module.exports = {
+  validateGetChallenges,
+};


### PR DESCRIPTION
## 작업 내용
- Challenge , Application,Participate 스키마 생성
- enum 추가

enum Field 
  - NEXTJS
  - CAREER
  - MODERNJS
  - WEB
  - API


enum DocType 
  - BLOG
  - DOCS

### getChallenges - cursor 기반의 페이지네이션 , 검색 가능 필터 가능
- application 에서 신청 상태를 확인하여 ACCEPTED 만 조회 되게 수정
####  getChallenges 지원하는 쿼리 파라미터
- pageSize:
- keyword:
- field:enum Field
- docType:enum DocType
- progress: ture/false

### getCreateChallenge 구현 -> 잘못된 부분이 있어서 다음 PR에서 수정했습니다. (pplication을 create 하는것으로 수정)

### participateChallenge 구현 
  1.useId 찾기
  2.해당 챌린지 찾기
  3.해당 챌린지에 남은 인원이 있는지 확인하고, 상태도 ACCEPTED 상태인지 확인 
  4. 만약에 이미 신청했으면 에러 반환
  5.남은 인원이 있으면 카운트 올리고 participate 생성


## 변경할 사항들
- getChallenges : orderBy가 필요 한가?? (아마 필요없는거 같음 )  , 유저데이터나 work 데이터 반환이 필요하면 추가할수 있음,  
- schema user 부분  role  을 임시로 optional하게 설정
- 
